### PR TITLE
ci: migrate snapshot publishing to central portal

### DIFF
--- a/gradle/promote.gradle
+++ b/gradle/promote.gradle
@@ -56,8 +56,8 @@ nexusPublishing {
             username = System.getenv('NEXUS_USERNAME')
             password = System.getenv('NEXUS_PASSWORD')
 
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace the retired Sonatype s01 staging endpoint with the Central Portal OSSRH compatibility endpoint
- publish snapshots through the Central Portal snapshot repository
- keep credentials, coordinates, and SDK code unchanged

## Validation

- `publishToSonatype --dry-run` succeeds with the updated Nexus configuration
- the PR snapshot workflow will validate authenticated publication

## Risk

CI-only publishing configuration. No runtime code, public API, dependency, min SDK, or artifact coordinate changes.

Linear: [SDK-5201](https://linear.app/rudderstack/issue/SDK-5201/migrate-legacy-android-integration-snapshot-publishing-off-sonatype)