### PR TITLE
chore(ci): remove commented-out Snyk block (SEC-409)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,16 +85,3 @@ jobs:
 #        run: ./gradlew android:codeCoverageReport
 #      - name: Upload coverage to Codecov
 #        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2.1.0
-
-#  security:
-#    needs: cancel_previous
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Grant execute permission for gradlew
-#        run: chmod +x gradlew
-#      - name: Snyk
-#        run: ./gradlew snyk-test
-#        env:
-#          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Removes a dead, commented-out Snyk CI step. Snyk is being decommissioned org-wide, replaced by ECR scanning.