### PR TITLE
chore: sdk-5434 update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pallabmaiti @itsdebs
+* @rudderlabs/sdk_team


### PR DESCRIPTION
## Summary

- set @rudderlabs/sdk_team as the default CODEOWNERS team
- remove narrow team or individual default ownership

## Validation

- verified the repository grants sdk_team write access
- verified the CODEOWNERS file contains the approved default rule

Linear: https://linear.app/rudderstack/issue/SDK-5434